### PR TITLE
BUG: Parse handling of default WXT summary command

### DIFF
--- a/app.py
+++ b/app.py
@@ -127,7 +127,6 @@ def parse_values(sample, **kwargs):
             ndict = dict(zip(parms, strip))
 
     else:
-        print("hey not hitting else")
         ndict = None
                  
     return ndict

--- a/app.py
+++ b/app.py
@@ -64,13 +64,11 @@ def parse_values(sample, **kwargs):
                                 "Pa={:f}H," +
                                 "Rc={:f}M," +
                                 "Th={:f}C," +
-                                "Vh={:f}N," +
-                                "Vs={:f}V," +
-                                "Vr={:f}" ,
+                                "Vh={:f}" ,
                                 sample.decode('utf-8')[:-1]
             )
             if data:
-                parms = ['Dm', 'Sm', 'Ta', 'Ua', 'Pa', 'Rc', 'Th', 'Vh', 'Vs', 'Vr']
+                parms = ['Dm', 'Sm', 'Ta', 'Ua', 'Pa', 'Rc', 'Th', 'Vh']
                 # Convert to a list to convert from parse result object
                 strip = [float(var) for var in data]
                 ndict = dict(zip(parms, strip))
@@ -129,6 +127,7 @@ def parse_values(sample, **kwargs):
             ndict = dict(zip(parms, strip))
 
     else:
+        print("hey not hitting else")
         ndict = None
                  
     return ndict
@@ -158,12 +157,12 @@ def start_publishing(args, plugin, dev, query, **kwargs):
     line = dev.readline()
     # Remove all leading/trailing checksum characters
     newstring = b''.join(bytes([byte]) for byte in line if byte  > 14)
-    # Check for valid command
-    sample = parse_values(newstring)
     # check for debug; output direct from the instrument
     if kwargs['debug'] == True:
         print(datetime.datetime.fromtimestamp(timestamp / 1e9).strftime('%Y-%m-%d %H:%M:%S.%f'), line)
         print(newstring)
+    # Check for valid command
+    sample = parse_values(newstring)
     # If valid parsed values, send to publishing
     if sample:
         # Define a list to hold the additional meta data for the heater

--- a/sage.yaml
+++ b/sage.yaml
@@ -1,6 +1,6 @@
 name: "waggle-wxt536"
 description: "Captures & uploads meteorological conditions from a Viasala WXT530 data stream."
-version: "0.24.10.22"
+version: "0.24.10.23"
 authors: "Joe O'Brien <obrienj@anl.gov>"
 collaborators: "Bhupendra Raut, Evan Keeler, Sujan Pal, and Yongho Kim"
 funding: "Community Research on Climate and Urban Science (CROCUS)"


### PR DESCRIPTION
After PR #19 , the default WXT summary command needed to be updated to remove additional voltages. 