### PR TITLE
BUG: WXT Heating Status Incorrectly Parsing

### DIFF
--- a/app.py
+++ b/app.py
@@ -42,9 +42,9 @@ def parse_values(sample, **kwargs):
             ndict = dict(zip(parms, strip))
             # Search for remaining heating options
             if parse.search("Vs={:f}V,", sample.decode('utf-8')):
-                ndict.update({'Vs' : [float(var) for var in parse.search("Vh={:f}V", sinput.decode('utf-8'))][0]})
+                ndict.update({'Vs' : [float(var) for var in parse.search("Vh={:f}V", sample.decode('utf-8'))][0]})
             if parse.search("Vr={:f}V,", sample.decode('utf-8')):
-                ndict.update({'Vr' : [float(var) for var in parse.search("Vh={:f}V", sinput.decode('utf-8'))][0]})
+                ndict.update({'Vr' : [float(var) for var in parse.search("Vh={:f}V", sample.decode('utf-8'))][0]})
             # Apply the heater status to the dictionary
             if parse.search("Vh={:f}N", sample.decode('utf-8')):
                 ndict.update({'Jo' : 1})

--- a/app.py
+++ b/app.py
@@ -42,9 +42,9 @@ def parse_values(sample, **kwargs):
             ndict = dict(zip(parms, strip))
             # Search for remaining heating options
             if parse.search("Vs={:f}V,", sample.decode('utf-8')):
-                ndict.update({'Vs' : [float(var) for var in parse.search("Vh={:f}V", sample.decode('utf-8'))][0]})
+                ndict.update({'Vs' : [float(var) for var in parse.search("Vs={:f}V", sample.decode('utf-8'))][0]})
             if parse.search("Vr={:f}V,", sample.decode('utf-8')):
-                ndict.update({'Vr' : [float(var) for var in parse.search("Vh={:f}V", sample.decode('utf-8'))][0]})
+                ndict.update({'Vr' : [float(var) for var in parse.search("Vr={:f}V", sample.decode('utf-8'))][0]})
             # Apply the heater status to the dictionary
             if parse.search("Vh={:f}N", sample.decode('utf-8')):
                 ndict.update({'Jo' : 1})


### PR DESCRIPTION
It was incorrectly assumed that the final character within the summary command would contain the heating status character. However, this status character is only contained within the `Vh` variable (Heating voltage). Therefore, to appropriately strip out this character, the summary parse has been updated to check separately for the reference and supply voltages. 

For future reference, the Vaisala WXT manual (`Chapter 7 - Retrieving Data Messages; Page 89`) contains the abbreviations, units and status messages. 